### PR TITLE
config.guess: linux - Add support for ppc64le machine

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -864,6 +864,9 @@ EOF
     ppc64:Linux:*:*)
 	echo powerpc64-${VENDOR:-unknown}-linux-gnu
 	exit 0 ;;
+    ppc64le:Linux:*:*)
+	echo powerpc64le-${VENDOR:-unknown}-linux-gnu
+	exit 0 ;;
     alpha:Linux:*:*)
 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
 	  EV5)   UNAME_MACHINE=alphaev5 ;;


### PR DESCRIPTION
Configure fails to guess ppc64le machine type under the Linux system.
This patch adds support to recognize ppc64le by adding it to the list
of valid Linux systems.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>