### PR TITLE
TravisCI: enable build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+dist: xenial
+arch:
+  - amd64
+  - ppc64le
+
+script:
+  - ./configure
+  - make
+  - sudo make install


### PR DESCRIPTION
Add .travis.yml file that build test on amd64/ppc64le

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>