### PR TITLE
lib/sysfs_class: fix build failure reported on GCC-11

### DIFF
--- a/lib/sysfs_class.c
+++ b/lib/sysfs_class.c
@@ -68,7 +68,6 @@ void sysfs_close_class(struct sysfs_class *cls)
  */
 static int cdev_name_equal(void *a, void *b)
 {
-	size_t length_a, length_b;
 	char *str_a, *str_b;
 
 	if (!a || !b)
@@ -77,13 +76,7 @@ static int cdev_name_equal(void *a, void *b)
 	str_a = (char *)a;
 	str_b = ((struct sysfs_class_device *)b)->name;
 
-	length_a = strnlen(str_a, SYSFS_NAME_LEN+1);
-	length_b = strnlen(str_b, SYSFS_NAME_LEN+1);
-
-	if (length_a != length_b)
-		return 0;
-
-	if (strncmp(str_a, str_b, length_a+1) == 0)
+	if (strncmp(str_a, str_b, SYSFS_NAME_LEN) == 0)
 		return 1;
 
 	return 0;


### PR DESCRIPTION
Christopher reported that, the build fails with GCC-11. It introduces a
-Wstringop-overread, that warns about reading past the end in string
functions. cdev_name_equal() does a comparison, which compares strings
past SYSFS_NAME_LEN. It currently calculates the string lengths of both
string and does a comparison on strings of equal length.

This patch refactors the function to compare, the strings until
SYSFS_NAME_LEN, removing the string length comparison logic.

Fixes #12 ("Build failure with GCC-11 due to stringop-overread")
Reported-by: Christopher Engelhard <ce@lcts.de>
Tested-by: Christopher Engelhard <ce@lcts.de>
Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>