### PR TITLE
man: Improve systool(1) man page

### DIFF
--- a/systool.1
+++ b/systool.1
@@ -1,10 +1,10 @@
-.TH SYSTOOL 1 "October 12, 2003" "Martin Pitt"
+.TH SYSTOOL 1 "2019-11-16" "sysfsutils"
 .SH NAME
 systool \- view system device information by bus, class, and topology
 
 .SH SYNOPSIS
 .B systool
-[\fIoptions \fR[\fIdevice\fR]]
+[\fIoptions\fP [\fIdevice\fP]]
 
 .SH DESCRIPTION
 Calling
@@ -30,43 +30,43 @@ filesystem mounted.
 .SH OPTIONS
 .TP
 .B \-a
-Show attributes of the requested resource
+Show attributes of the requested resource.
 .TP
-.B \-b \fIbus
-Show information for a specific bus
+.B \-b \fIbus\fP
+Show information for a specific bus.
 .TP
-.B \-c \fIclass
-Show information for a specific class
+.B \-c \fIclass\fP
+Show information for a specific class.
 .TP
 .B \-d
-Show only devices
+Show only devices.
 .TP
 .B \-h
-Show usage
+Show usage.
 .TP
-.B \-m \fImodule_name
-Show information for a specific module
+.B \-m \fImodule_name\fP
+Show information for a specific module.
 .TP
 .B \-p
-Show absolute sysfs path to the resource
+Show absolute sysfs path to the resource.
 .TP
 .B \-v
-Show all attributes with values
+Show all attributes with values.
 .TP
-.B \-A \fIattribute
-Show attribute value for the requested resource
+.B \-A \fIattribute\fP
+Show attribute value for the requested resource.
 .TP
 .B \-D
-Show only drivers
+Show only drivers.
 .TP
 .B \-P
-Show device's parent
+Show device's parent.
 
 .SH SEE ALSO
 .P
 The web page of
 .B libsysfs
-at http://linux\-diag.sourceforge.net/Sysfsutils.html
+at <http://linux\-diag.sourceforge.net/Sysfsutils.html>.
 
 .SH AUTHOR
 .B systool
@@ -74,4 +74,4 @@ was written by Ananth Mavinakayanahalli <ananth@in.ibm.com> and
 Daniel Stekloff <dsteklof@us.ibm.com>.
 .P
 This man page was contributed by Martin Pitt <mpitt@debian.org> for
-the Debian GNU/Linux system (but may be used by others).
+the Debian system (but may be used by others).


### PR DESCRIPTION
- Fix troff markup.
- End sentences with a full-stop.
- Use the project name in the .TH source field instead of the author.
- Remove GNU/Linux from Debian reference.
