### PR TITLE
Check that sysfs is actually mounted in sysfs_get_mnt_path() and fail if not

### DIFF
--- a/lib/sysfs_utils.c
+++ b/lib/sysfs_utils.c
@@ -25,6 +25,7 @@
 
 #include "libsysfs.h"
 #include "sysfs.h"
+#include <mntent.h>
 
 /**
  * sysfs_remove_trailing_slash: Removes any trailing '/' in the given path
@@ -56,6 +57,9 @@ int sysfs_get_mnt_path(char *mnt_path, size_t len)
 {
 	static char sysfs_path[SYSFS_PATH_MAX] = "";
 	const char *sysfs_path_env;
+	FILE *mnt;
+	struct mntent *mntent;
+	int ret;
 
 	if (len == 0 || mnt_path == NULL)
 		return -1;
@@ -67,12 +71,31 @@ int sysfs_get_mnt_path(char *mnt_path, size_t len)
 		if (sysfs_path_env != NULL) {
 			safestrcpymax(mnt_path, sysfs_path_env, len);
 			sysfs_remove_trailing_slash(mnt_path);
-			return 0;
+		} else {
+			safestrcpymax(mnt_path, SYSFS_MNT_PATH, len);
 		}
-		safestrcpymax(mnt_path, SYSFS_MNT_PATH, len);
 	}
 
-	return 0;
+	/* check that mount point is indeed mounted */
+	ret = -1;
+	mnt = setmntent(SYSFS_PROC_MNTS, "r");
+	if (mnt == NULL) {
+		dprintf("Error getting mount information\n");
+		return -1;
+	}
+	while ((mntent = getmntent(mnt)) != NULL) {
+		if (strcmp(mntent->mnt_type, SYSFS_FSTYPE_NAME) == 0 &&
+		    strcmp(mntent->mnt_dir, mnt_path) == 0) {
+			ret = 0;
+			break;
+		}
+	}
+	endmntent(mnt);
+
+	if (ret < 0)
+		errno = ENOENT;
+
+	return ret;
 }
 
 /**


### PR DESCRIPTION
Fixes behavioral breakage compared to 1.3.

This patch has been carried over in Debian for a while now, so it would be nice to get it merged upstream to reduce the delta. I've fixed a few minor coding style issues from the original.