### PR TITLE
test/libsysfs.conf: remove the obsolete build requirement

### DIFF
--- a/test/libsysfs.conf
+++ b/test/libsysfs.conf
@@ -4,9 +4,8 @@
 # Values defined here will be used to dynamically build a header file that
 # gets used while compiling the testsuite.
 
-# NOTE NOTE NOTE: If you change values in this file, please make sure that
-# you run "make clean" and "make" (in the "test" directory) for the changes
-# to take effect.
+# NOTE: If you change values in this file, please make sure that you run
+# "make" (in the "test" directory) for the changes to take effect.
 
 
 # A valid directory path under sysfs

--- a/test/libsysfs.conf-suse
+++ b/test/libsysfs.conf-suse
@@ -4,9 +4,8 @@
 # Values defined here will be used to dynamically build a header file that
 # gets used while compiling the testsuite.
 
-# NOTE NOTE NOTE: If you change values in this file, please make sure that
-# you run "make clean" and "make" (in the "test" directory) for the changes
-# to take effect.
+# NOTE: If you change values in this file, please make sure that you run
+# "make" (in the "test" directory) for the changes to take effect.
 
 
 # A valid directory path under sysfs


### PR DESCRIPTION
After #18, we do not need "make clean" anymore after changes to
libsysfs.conf. Remove that requirement from the description.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>