### PR TITLE
Build system improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.la
 *.lo
 *.o
+*.pc
 .deps
 .libs
 INSTALL

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = systool
 systool_SOURCES = systool.c names.c names.h
-LDADD = ../lib/libsysfs.la
+LDADD = $(top_builddir)/lib/libsysfs.la
 EXTRA_CFLAGS = @EXTRA_CFLAGS@
-AM_CPPFLAGS = -I../include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = -Wall -W -Wextra -Wstrict-prototypes $(EXTRA_CFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ AC_CHECK_FUNCS([bzero isascii memset strchr strerror strrchr strstr strtol])
 
 AC_CONFIG_FILES([Makefile
                  lib/Makefile
+                 lib/libsysfs.pc
                  cmd/Makefile
                  test/Makefile])
 AC_CONFIG_HEADERS([config.h])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,3 +1,8 @@
+EXTRA_DIST = libsysfs.pc.in
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libsysfs.pc
+
 lib_LTLIBRARIES = libsysfs.la
 libsysfs_la_SOURCES = sysfs_utils.c sysfs_attr.c sysfs_class.c dlist.c \
       sysfs_device.c sysfs_driver.c sysfs_bus.c sysfs_module.c sysfs.h

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -6,7 +6,7 @@ pkgconfig_DATA = libsysfs.pc
 lib_LTLIBRARIES = libsysfs.la
 libsysfs_la_SOURCES = sysfs_utils.c sysfs_attr.c sysfs_class.c dlist.c \
       sysfs_device.c sysfs_driver.c sysfs_bus.c sysfs_module.c sysfs.h
-libsysfs_la_CPPFLAGS = -I../include
+libsysfs_la_CPPFLAGS = -I$(top_srcdir)/include
 libsysfs_la_LDFLAGS = -version-info 2:1:0
 EXTRA_CFLAGS = @EXTRA_CLFAGS@
 libsysfs_la_CFLAGS = -Wall -W -Wextra -Wstrict-prototypes $(EXTRA_CLFAGS)

--- a/lib/libsysfs.pc.in
+++ b/lib/libsysfs.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libsysfs
+Description: interface to Linux sysfs
+Version: @VERSION@
+URL: https://github.com/linux-ras/sysfsutils
+Libs: -L${libdir} -lsysfs
+Cflags: -I${includedir}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS = dlist_test get_device get_driver get_module testlibsysfs
+check_PROGRAMS = dlist_test get_device get_driver get_module testlibsysfs
 BUILT_SOURCES = test.h
 CLEANFILES = test.h
 test.h: libsysfs.conf create-test

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = dlist_test get_device get_driver get_module testlibsysfs
 BUILT_SOURCES = test.h
 CLEANFILES = test.h
 test.h: libsysfs.conf create-test
-	./create-test
+	$(AM_V_GEN) ./create-test
 get_device_SOURCES = get_device.c
 get_driver_SOURCES = get_driver.c
 get_module_SOURCES = get_module.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,15 +2,15 @@ check_PROGRAMS = dlist_test get_device get_driver get_module testlibsysfs
 BUILT_SOURCES = test.h
 CLEANFILES = test.h
 test.h: libsysfs.conf create-test
-	$(AM_V_GEN) ./create-test
+	$(AM_V_GEN) $(srcdir)/create-test $(srcdir)/libsysfs.conf
 get_device_SOURCES = get_device.c
 get_driver_SOURCES = get_driver.c
 get_module_SOURCES = get_module.c
 testlibsysfs_SOURCES = test.c test_attr.c test_bus.c test_class.c \
 		       test_device.c test_driver.c test_module.c test_utils.c \
 		       testout.c test-defs.h libsysfs.conf create-test
-AM_CPPFLAGS = -I../include
-LDADD = ../lib/libsysfs.la
+AM_CPPFLAGS = -I$(top_srcdir)/include
+LDADD = $(top_builddir)/lib/libsysfs.la
 EXTRA_CFLAGS = @EXTRA_CLFAGS@
 AM_CFLAGS = -Wall -W -Wextra -Wstrict-prototypes $(EXTRA_CLFAGS)
 

--- a/test/create-test
+++ b/test/create-test
@@ -2,7 +2,7 @@
 
 rm -f test.h
 
-conf_file=./libsysfs.conf
+conf_file=${1:-libsysfs.conf}
 
 . $conf_file
 


### PR DESCRIPTION
This adds a libsysfs.pc file, derived from the one used in Debian for pkg-config use. Fixes a silent rule for test.h. Moves the unit tests into a more appropriate automake variable. Fixes out-of-tree build support.