### PR TITLE
Rename dprintf() debugging macro do debugprintf()

### DIFF
--- a/lib/sysfs.h
+++ b/lib/sysfs.h
@@ -54,9 +54,9 @@ extern struct dlist *get_attributes_list(struct dlist *alist, const char *path);
 
 /* Debugging */
 #ifdef DEBUG
-#define dprintf(format, arg...) fprintf(stderr, format, ## arg)
+#define dbg_printf(format, arg...) fprintf(stderr, format, ## arg)
 #else
-#define dprintf(format, arg...) do { } while (0)
+#define dbg_printf(format, arg...) do { } while (0)
 #endif
 
 #endif /* _SYSFS_H_ */

--- a/lib/sysfs_bus.c
+++ b/lib/sysfs_bus.c
@@ -115,12 +115,12 @@ struct dlist *sysfs_get_bus_devices(struct sysfs_bus *bus)
 			safestrcat(devpath, "/");
 			safestrcat(devpath, curlink);
 			if (sysfs_get_link(devpath, target, SYSFS_PATH_MAX)) {
-				dprintf("Error getting link - %s\n", devpath);
+				dbg_printf("Error getting link - %s\n", devpath);
 				continue;
 			}
 			dev = sysfs_open_device_path(target);
 			if (!dev) {
-				dprintf("Error opening device at %s\n",
+				dbg_printf("Error opening device at %s\n",
 								target);
 				continue;
 			}
@@ -171,7 +171,7 @@ struct dlist *sysfs_get_bus_drivers(struct sysfs_bus *bus)
 			safestrcat(drvpath, curdir);
 			drv = sysfs_open_driver_path(drvpath);
 			if (!drv) {
-				dprintf("Error opening driver at %s\n",
+				dbg_printf("Error opening driver at %s\n",
 								drvpath);
 				continue;
 			}
@@ -202,7 +202,7 @@ struct sysfs_bus *sysfs_open_bus(const char *name)
 
 	memset(buspath, 0, SYSFS_PATH_MAX);
 	if (sysfs_get_mnt_path(buspath, SYSFS_PATH_MAX)) {
-		dprintf("Sysfs not supported on this system\n");
+		dbg_printf("Sysfs not supported on this system\n");
 		return NULL;
 	}
 
@@ -211,18 +211,18 @@ struct sysfs_bus *sysfs_open_bus(const char *name)
 	safestrcat(buspath, "/");
 	safestrcat(buspath, name);
 	if (sysfs_path_is_dir(buspath)) {
-		dprintf("Invalid path to bus: %s\n", buspath);
+		dbg_printf("Invalid path to bus: %s\n", buspath);
 		return NULL;
 	}
 	bus = alloc_bus();
 	if (!bus) {
-		dprintf("calloc failed\n");
+		dbg_printf("calloc failed\n");
 		return NULL;
 	}
 	safestrcpy(bus->name, name);
 	safestrcpy(bus->path, buspath);
 	if (sysfs_remove_trailing_slash(bus->path)) {
-		dprintf("Incorrect path to bus %s\n", bus->path);
+		dbg_printf("Incorrect path to bus %s\n", bus->path);
 		sysfs_close_bus(bus);
 		return NULL;
 	}
@@ -259,13 +259,13 @@ struct sysfs_device *sysfs_get_bus_device(struct sysfs_bus *bus,
 	safestrcat(devpath, "/");
 	safestrcat(devpath, id);
 	if (sysfs_path_is_link(devpath)) {
-		dprintf("No such device %s on bus %s?\n", id, bus->name);
+		dbg_printf("No such device %s on bus %s?\n", id, bus->name);
 		return NULL;
 	}
 	if (!sysfs_get_link(devpath, target, SYSFS_PATH_MAX)) {
 		dev = sysfs_open_device_path(target);
 		if (!dev) {
-			dprintf("Error opening device at %s\n", target);
+			dbg_printf("Error opening device at %s\n", target);
 			return NULL;
 		}
 		if (!bus->devices)
@@ -307,7 +307,7 @@ struct sysfs_driver *sysfs_get_bus_driver(struct sysfs_bus *bus,
 	safestrcat(drvpath, drvname);
 	drv = sysfs_open_driver_path(drvpath);
 	if (!drv) {
-		dprintf("Error opening driver at %s\n", drvpath);
+		dbg_printf("Error opening driver at %s\n", drvpath);
 		return NULL;
 	}
 	if (!bus->drivers)

--- a/lib/sysfs_class.c
+++ b/lib/sysfs_class.c
@@ -180,14 +180,14 @@ struct sysfs_class_device *sysfs_open_class_device_path(const char *path)
 	 * a link to the actual class device if a directory isn't found
 	 */
 	if (sysfs_path_is_dir(path)) {
-		dprintf("%s: Directory not found, checking for a link\n", path);
+		dbg_printf("%s: Directory not found, checking for a link\n", path);
 		if (!sysfs_path_is_link(path)) {
 			if (sysfs_get_link(path, temp_path, SYSFS_PATH_MAX)) {
-				dprintf("Error retrieving link at %s\n", path);
+				dbg_printf("Error retrieving link at %s\n", path);
 				return NULL;
 			}
 		} else {
-			dprintf("%s is not a valid class device path\n", path);
+			dbg_printf("%s is not a valid class device path\n", path);
 			return NULL;
 		}
 	} else
@@ -195,19 +195,19 @@ struct sysfs_class_device *sysfs_open_class_device_path(const char *path)
 
 	cdev = alloc_class_device();
 	if (!cdev) {
-		dprintf("calloc failed\n");
+		dbg_printf("calloc failed\n");
 		return NULL;
 	}
 	if (sysfs_get_name_from_path(temp_path, cdev->name, SYSFS_NAME_LEN)) {
 		errno = EINVAL;
-		dprintf("Error getting class device name\n");
+		dbg_printf("Error getting class device name\n");
 		sysfs_close_class_device(cdev);
 		return NULL;
 	}
 
 	safestrcpy(cdev->path, temp_path);
 	if (sysfs_remove_trailing_slash(cdev->path)) {
-		dprintf("Invalid path to class device %s\n", cdev->path);
+		dbg_printf("Invalid path to class device %s\n", cdev->path);
 		sysfs_close_class_device(cdev);
 		return NULL;
 	}
@@ -251,7 +251,7 @@ struct sysfs_class_device *sysfs_get_classdev_parent
 	*c = '\0';
 
 	if ((strncmp(tmp_path, abs_path, strlen(abs_path))) == 0) {
-		dprintf("Class device %s doesn't have a parent\n",
+		dbg_printf("Class device %s doesn't have a parent\n",
 				clsdev->name);
 		return NULL;
 	}
@@ -280,7 +280,7 @@ static int get_classdev_path(const char *classname, const char *clsdev,
 		return -1;
 	}
 	if (sysfs_get_mnt_path(path, len) != 0) {
-		dprintf("Error getting sysfs mount path\n");
+		dbg_printf("Error getting sysfs mount path\n");
 		return -1;
 	}
 	safestrcatmax(path, "/", len);
@@ -324,14 +324,14 @@ struct sysfs_class_device *sysfs_open_class_device
 	memset(devpath, 0, SYSFS_PATH_MAX);
 	if ((get_classdev_path(classname, name, devpath,
 					SYSFS_PATH_MAX)) != 0) {
-		dprintf("Error getting to device %s on class %s\n",
+		dbg_printf("Error getting to device %s on class %s\n",
 							name, classname);
 		return NULL;
 	}
 
 	cdev = sysfs_open_class_device_path(devpath);
 	if (!cdev) {
-		dprintf("Error getting class device %s from class %s\n",
+		dbg_printf("Error getting class device %s from class %s\n",
 				name, classname);
 		return NULL;
 	}
@@ -414,7 +414,7 @@ struct sysfs_class *sysfs_open_class(const char *name)
 
 	memset(classpath, 0, SYSFS_PATH_MAX);
 	if ((sysfs_get_mnt_path(classpath, SYSFS_PATH_MAX)) != 0) {
-		dprintf("Sysfs not supported on this system\n");
+		dbg_printf("Sysfs not supported on this system\n");
 		return NULL;
 	}
 
@@ -431,19 +431,19 @@ struct sysfs_class *sysfs_open_class(const char *name)
 	safestrcat(classpath, name);
 done:
 	if (sysfs_path_is_dir(classpath)) {
-		dprintf("Class %s not found on the system\n", name);
+		dbg_printf("Class %s not found on the system\n", name);
 		return NULL;
 	}
 
 	cls = alloc_class();
 	if (cls == NULL) {
-		dprintf("calloc failed\n");
+		dbg_printf("calloc failed\n");
 		return NULL;
 	}
 	safestrcpy(cls->name, name);
 	safestrcpy(cls->path, classpath);
 	if ((sysfs_remove_trailing_slash(cls->path)) != 0) {
-		dprintf("Invalid path to class device %s\n", cls->path);
+		dbg_printf("Invalid path to class device %s\n", cls->path);
 		sysfs_close_class(cls);
 		return NULL;
 	}
@@ -481,7 +481,7 @@ struct sysfs_class_device *sysfs_get_class_device(struct sysfs_class *cls,
 	safestrcat(path, name);
 	cdev = sysfs_open_class_device_path(path);
 	if (!cdev) {
-		dprintf("Error opening class device at %s\n", path);
+		dbg_printf("Error opening class device at %s\n", path);
 		return NULL;
 	}
 	if (!cls->devices)

--- a/lib/sysfs_device.c
+++ b/lib/sysfs_device.c
@@ -174,23 +174,23 @@ struct sysfs_device *sysfs_open_device_path(const char *path)
 		return NULL;
 	}
 	if (sysfs_path_is_dir(path)) {
-		dprintf("Incorrect path to device: %s\n", path);
+		dbg_printf("Incorrect path to device: %s\n", path);
 		return NULL;
 	}
 	dev = alloc_device();
 	if (!dev) {
-		dprintf("Error allocating device at %s\n", path);
+		dbg_printf("Error allocating device at %s\n", path);
 		return NULL;
 	}
 	if (sysfs_get_name_from_path(path, dev->bus_id, SYSFS_NAME_LEN)) {
 		errno = EINVAL;
-		dprintf("Error getting device bus_id\n");
+		dbg_printf("Error getting device bus_id\n");
 		sysfs_close_device(dev);
 		return NULL;
 	}
 	safestrcpy(dev->path, path);
 	if (sysfs_remove_trailing_slash(dev->path)) {
-		dprintf("Invalid path to device %s\n", dev->path);
+		dbg_printf("Invalid path to device %s\n", dev->path);
 		sysfs_close_device(dev);
 		return NULL;
 	}
@@ -202,15 +202,15 @@ struct sysfs_device *sysfs_open_device_path(const char *path)
 	safestrcpy(dev->name, dev->bus_id);
 
 	if (sysfs_get_device_bus(dev))
-		dprintf("Could not get device bus\n");
+		dbg_printf("Could not get device bus\n");
 
 	if (get_dev_driver(dev)) {
-		dprintf("Could not get device %s's driver\n", dev->bus_id);
+		dbg_printf("Could not get device %s's driver\n", dev->bus_id);
 		safestrcpy(dev->driver_name, SYSFS_UNKNOWN);
 	}
 
 	if (get_dev_subsystem(dev)) {
-		dprintf("Could not get device %s's subsystem\n", dev->bus_id);
+		dbg_printf("Could not get device %s's subsystem\n", dev->bus_id);
 		safestrcpy(dev->subsystem, SYSFS_UNKNOWN);
 	}
 	return dev;
@@ -235,7 +235,7 @@ struct sysfs_device *sysfs_open_device_tree(const char *path)
 	}
 	rootdev = sysfs_open_device_path(path);
 	if (rootdev == NULL) {
-		dprintf("Error opening root device at %s\n", path);
+		dbg_printf("Error opening root device at %s\n", path);
 		return NULL;
 	}
 
@@ -245,7 +245,7 @@ struct sysfs_device *sysfs_open_device_tree(const char *path)
 				struct sysfs_device) {
 			new = sysfs_open_device_tree(cur->path);
 			if (new == NULL) {
-				dprintf("Error opening device tree at %s\n",
+				dbg_printf("Error opening device tree at %s\n",
 						cur->path);
 				sysfs_close_device_tree(rootdev);
 				return NULL;
@@ -311,7 +311,7 @@ static int get_device_absolute_path(const char *device,	const char *bus,
 
 	memset(bus_path, 0, SYSFS_PATH_MAX);
 	if (sysfs_get_mnt_path(bus_path, SYSFS_PATH_MAX)) {
-		dprintf ("Sysfs not supported on this system\n");
+		dbg_printf ("Sysfs not supported on this system\n");
 		return -1;
 	}
 	safestrcat(bus_path, "/");
@@ -327,7 +327,7 @@ static int get_device_absolute_path(const char *device,	const char *bus,
 	 * Now read this link to reach to the device.
 	 */
 	if (sysfs_get_link(bus_path, path, psize)) {
-		dprintf("Error getting to device %s\n", device);
+		dbg_printf("Error getting to device %s\n", device);
 		return -1;
 	}
 	return 0;
@@ -356,13 +356,13 @@ struct sysfs_device *sysfs_open_device(const char *bus,	const char *bus_id)
 	memset(sysfs_path, 0, SYSFS_PATH_MAX);
 	if (get_device_absolute_path(bus_id, bus, sysfs_path,
 				SYSFS_PATH_MAX)) {
-		dprintf("Error getting to device %s\n", bus_id);
+		dbg_printf("Error getting to device %s\n", bus_id);
 		return NULL;
 	}
 
 	device = sysfs_open_device_path(sysfs_path);
 	if (!device) {
-		dprintf("Error opening device %s\n", bus_id);
+		dbg_printf("Error opening device %s\n", bus_id);
 		return NULL;
 	}
 	return device;
@@ -391,14 +391,14 @@ struct sysfs_device *sysfs_get_device_parent(struct sysfs_device *dev)
 	safestrcpy(ppath, dev->path);
 	tmp = strrchr(ppath, '/');
 	if (!tmp) {
-		dprintf("Invalid path to device %s\n", ppath);
+		dbg_printf("Invalid path to device %s\n", ppath);
 		return NULL;
 	}
 	if (*(tmp + 1) == '\0') {
 		*tmp = '\0';
 		tmp = strrchr(tmp, '/');
 		if (tmp == NULL) {
-			dprintf("Invalid path to device %s\n", ppath);
+			dbg_printf("Invalid path to device %s\n", ppath);
 			return NULL;
 		}
 	}
@@ -406,20 +406,20 @@ struct sysfs_device *sysfs_get_device_parent(struct sysfs_device *dev)
 
 	/* Make sure we're at the top of the device tree */
 	if (sysfs_get_mnt_path(dpath, SYSFS_PATH_MAX) != 0) {
-		dprintf("Sysfs not supported on this system\n");
+		dbg_printf("Sysfs not supported on this system\n");
 		return NULL;
 	}
 	safestrcat(dpath, "/");
 	safestrcat(dpath, SYSFS_DEVICES_NAME);
 
 	if (strcmp(dpath, ppath) == 0) {
-		dprintf("Device at %s does not have a parent\n", dev->path);
+		dbg_printf("Device at %s does not have a parent\n", dev->path);
 		return NULL;
 	}
 
 	dev->parent = sysfs_open_device_path(ppath);
 	if (!dev->parent) {
-		dprintf("Error opening device %s's parent at %s\n",
+		dbg_printf("Error opening device %s's parent at %s\n",
 					dev->bus_id, ppath);
 		return NULL;
 	}

--- a/lib/sysfs_driver.c
+++ b/lib/sysfs_driver.c
@@ -130,27 +130,27 @@ struct sysfs_driver *sysfs_open_driver_path(const char *path)
 		return NULL;
 	}
 	if (sysfs_path_is_dir(path)) {
-		dprintf("Invalid path to driver: %s\n", path);
+		dbg_printf("Invalid path to driver: %s\n", path);
 		return NULL;
 	}
 	driver = alloc_driver();
 	if (!driver) {
-		dprintf("Error allocating driver at %s\n", path);
+		dbg_printf("Error allocating driver at %s\n", path);
 		return NULL;
 	}
 	if (sysfs_get_name_from_path(path, driver->name, SYSFS_NAME_LEN)) {
-		dprintf("Error getting driver name from path\n");
+		dbg_printf("Error getting driver name from path\n");
 		free(driver);
 		return NULL;
 	}
 	safestrcpy(driver->path, path);
 	if (sysfs_remove_trailing_slash(driver->path)) {
-		dprintf("Invalid path to driver %s\n", driver->path);
+		dbg_printf("Invalid path to driver %s\n", driver->path);
 		sysfs_close_driver(driver);
 		return NULL;
 	}
 	if (get_driver_bus(driver)) {
-		dprintf("Could not get the bus driver is on\n");
+		dbg_printf("Could not get the bus driver is on\n");
 		sysfs_close_driver(driver);
 		return NULL;
 	}
@@ -175,7 +175,7 @@ static int get_driver_path(const char *bus, const char *drv,
 		return -1;
 	}
 	if (sysfs_get_mnt_path(path, psize)) {
-		dprintf("Error getting sysfs mount path\n");
+		dbg_printf("Error getting sysfs mount path\n");
 		return -1;
 	}
 	safestrcatmax(path, "/", psize);
@@ -208,12 +208,12 @@ struct sysfs_driver *sysfs_open_driver(const char *bus_name,
 
 	memset(path, 0, SYSFS_PATH_MAX);
 	if (get_driver_path(bus_name, drv_name, path, SYSFS_PATH_MAX)) {
-		dprintf("Error getting to driver %s\n", drv_name);
+		dbg_printf("Error getting to driver %s\n", drv_name);
 		return NULL;
 	}
 	driver = sysfs_open_driver_path(path);
 	if (!driver) {
-		dprintf("Error opening driver at %s\n", path);
+		dbg_printf("Error opening driver at %s\n", path);
 		return NULL;
 	}
 	return driver;
@@ -244,7 +244,7 @@ struct dlist *sysfs_get_driver_devices(struct sysfs_driver *drv)
 
 			dev = sysfs_open_device(drv->bus, ln);
 			if (!dev) {
-				dprintf("Error opening driver's device\n");
+				dbg_printf("Error opening driver's device\n");
 				sysfs_close_list(linklist);
 				return NULL;
 			}
@@ -253,7 +253,7 @@ struct dlist *sysfs_get_driver_devices(struct sysfs_driver *drv)
 					(sizeof(struct sysfs_device),
 					 sysfs_close_driver_device);
 				if (!drv->devices) {
-					dprintf("Error creating device list\n");
+					dbg_printf("Error creating device list\n");
 					sysfs_close_list(linklist);
 					return NULL;
 				}

--- a/lib/sysfs_module.c
+++ b/lib/sysfs_module.c
@@ -87,24 +87,24 @@ struct sysfs_module *sysfs_open_module_path(const char *path)
 		return NULL;
 	}
 	if ((sysfs_path_is_dir(path)) != 0) {
-		dprintf("%s is not a valid path to a module\n", path);
+		dbg_printf("%s is not a valid path to a module\n", path);
 		return NULL;
 	}
 	mod = alloc_module();
 	if (mod == NULL) {
-		dprintf("calloc failed\n");
+		dbg_printf("calloc failed\n");
 		return NULL;
 	}
 	if ((sysfs_get_name_from_path(path, mod->name, SYSFS_NAME_LEN)) != 0) {
 		errno = EINVAL;
-		dprintf("Error getting module name\n");
+		dbg_printf("Error getting module name\n");
 		sysfs_close_module(mod);
 		return NULL;
 	}
 
 	safestrcpy(mod->path, path);
 	if ((sysfs_remove_trailing_slash(mod->path)) != 0) {
-		dprintf("Invalid path to module %s\n", mod->path);
+		dbg_printf("Invalid path to module %s\n", mod->path);
 		sysfs_close_module(mod);
 		return NULL;
 	}
@@ -128,7 +128,7 @@ struct sysfs_module *sysfs_open_module(const char *name)
 
 	memset(modpath, 0, SYSFS_PATH_MAX);
 	if ((sysfs_get_mnt_path(modpath, SYSFS_PATH_MAX)) != 0) {
-		dprintf("Sysfs not supported on this system\n");
+		dbg_printf("Sysfs not supported on this system\n");
 		return NULL;
 	}
 
@@ -138,19 +138,19 @@ struct sysfs_module *sysfs_open_module(const char *name)
 	safestrcat(modpath, name);
 
 	if ((sysfs_path_is_dir(modpath)) != 0) {
-		dprintf("Module %s not found on the system\n", name);
+		dbg_printf("Module %s not found on the system\n", name);
 		return NULL;
 	}
 
 	mod = alloc_module();
 	if (mod == NULL) {
-		dprintf("calloc failed\n");
+		dbg_printf("calloc failed\n");
 		return NULL;
 	}
 	safestrcpy(mod->name, name);
 	safestrcpy(mod->path, modpath);
 	if ((sysfs_remove_trailing_slash(mod->path)) != 0) {
-		dprintf("Invalid path to module %s\n", mod->path);
+		dbg_printf("Invalid path to module %s\n", mod->path);
 		sysfs_close_module(mod);
 		return NULL;
 	}

--- a/lib/sysfs_utils.c
+++ b/lib/sysfs_utils.c
@@ -80,7 +80,7 @@ int sysfs_get_mnt_path(char *mnt_path, size_t len)
 	ret = -1;
 	mnt = setmntent(SYSFS_PROC_MNTS, "r");
 	if (mnt == NULL) {
-		dprintf("Error getting mount information\n");
+		dbg_printf("Error getting mount information\n");
 		return -1;
 	}
 	while ((mntent = getmntent(mnt)) != NULL) {
@@ -297,7 +297,7 @@ int sysfs_path_is_dir(const char *path)
 		return 1;
 	}
 	if ((lstat(path, &astats)) != 0) {
-		dprintf("stat() failed\n");
+		dbg_printf("stat() failed\n");
 		return 1;
 	}
 	if (S_ISDIR(astats.st_mode))
@@ -320,7 +320,7 @@ int sysfs_path_is_link(const char *path)
 		return 1;
 	}
 	if ((lstat(path, &astats)) != 0) {
-		dprintf("stat() failed\n");
+		dbg_printf("stat() failed\n");
 		return 1;
 	}
 	if (S_ISLNK(astats.st_mode))
@@ -343,7 +343,7 @@ int sysfs_path_is_file(const char *path)
 		return 1;
 	}
 	if ((stat(path, &astats)) != 0) {
-		dprintf("stat() failed\n");
+		dbg_printf("stat() failed\n");
 		return 1;
 	}
 	if (S_ISREG(astats.st_mode))


### PR DESCRIPTION
`dprintf()` is a function in libc and might be included when including
`stdio.h`:

./sysfs.h:59:9: warning: 'dprintf' macro redefined [-Wmacro-redefined]
        ^
/usr/include/bits/stdio2.h:148:12: note: previous definition is here
           ^
1 warning generated.

This can be reproduced by compiling with `clang` while specifying `-Wp,-D_FORTIFY_SOURCE=2 -O2` as `$CFLAGS`.