### PR TITLE
Simplify symlink canonicalization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,9 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([1.11 foreign])
 AM_SILENT_RULES([yes])
 
+# Check for C and POSIX extensions (run before any macro using the C compiler)
+AC_USE_SYSTEM_EXTENSIONS
+
 # Checks for KLIBC support (should be before LT_INIT and AC_PROG_CC)
 AC_CHECK_KLIBC
 


### PR DESCRIPTION
Use the GNU extension to canonicalize instead of open-coding it.

[guillem@hadrons.org:
 - Add AC_USE_SYSTEM_EXTENSIONS.
 - Include <stdlib.h> ]

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=481015#25
Signed-off-by: Guillem Jover <guillem@hadrons.org>