### PR TITLE
Modify "my_strncat" function

### DIFF
--- a/lib/sysfs_utils.c
+++ b/lib/sysfs_utils.c
@@ -375,8 +375,8 @@ char *my_strncat(char *to, const char *from, size_t max)
 {
 	size_t i = 0;
 
-	while (i < max && to[i] != '\0')
+	while (to[i] != '\0')
 		i++;
-	my_strncpy(to+i, from, max-i);
+	my_strncpy(to+i, from, max);
 	return to;
 }


### PR DESCRIPTION
The meaning of the "len" parameter in the my_strncat function is the size limit for copying characters from "from", not the size limit for "to" after copying.
Also, the "#define safestrcat(to, from) my_strncat(to, from, sizeof(to) - strlen(to) - 1)" has already imposed a limit on max based on the size of "to".
Modify the function to prevent truncation of content when too many bytes are passed to the my_strcat function.